### PR TITLE
[ compat ] with current Idris

### DIFF
--- a/Code/Lecture1/Core/Core.idr
+++ b/Code/Lecture1/Core/Core.idr
@@ -57,6 +57,10 @@ map : (a -> b) -> Core a -> Core b
 map f (MkCore a) = MkCore (map (map f) a)
 
 export %inline
+ignore : Core a -> Core ()
+ignore = map (\ _ => ())
+
+export %inline
 (<$>) : (a -> b) -> Core a -> Core b
 (<$>) f (MkCore a) = MkCore (map (map f) a)
 
@@ -68,6 +72,11 @@ export %inline
                    (\x => case x of
                                Left err => pure (Left err)
                                Right val => runCore (f val)))
+
+-- Monad (specialised)
+export %inline
+(>>) : Core () -> Core b -> Core b
+ma >> mb = ma >>= \ () => mb
 
 -- Applicative (specialised)
 export %inline
@@ -111,7 +120,7 @@ traverse f xs = traverse' f xs []
 
 export
 traverseList1 : (a -> Core b) -> List1 a -> Core (List1 b)
-traverseList1 f (x :: xs) = [| f x :: traverse f xs |]
+traverseList1 f (x ::: xs) = [| f x ::: traverse f xs |]
 
 export
 traverseVect : (a -> Core b) -> Vect n a -> Core (Vect n b)
@@ -124,15 +133,15 @@ traverseOpt f Nothing = pure Nothing
 traverseOpt f (Just x) = map Just (f x)
 
 export
-traverse_ : (a -> Core b) -> List a -> Core ()
+traverse_ : (a -> Core ()) -> List a -> Core ()
 traverse_ f [] = pure ()
 traverse_ f (x :: xs)
     = do f x
          traverse_ f xs
 
 export
-traverseList1_ : (a -> Core b) -> List1 a -> Core ()
-traverseList1_ f (x :: xs) = do
+traverseList1_ : (a -> Core ()) -> List1 a -> Core ()
+traverseList1_ f (x ::: xs) = do
   f x
   traverse_ f xs
 

--- a/Code/Lecture1/lecture1.ipkg
+++ b/Code/Lecture1/lecture1.ipkg
@@ -1,3 +1,14 @@
 package lecture1
 
 opts = "-p contrib"
+
+modules
+ = Ref
+ , Search
+ , QTT
+ , WarmupExercise.Ex2
+ , WarmupExercise.Ex1
+ , WarmupExercise.Ex3
+ , RLE
+ , Append
+ , Core.Core

--- a/Code/Lecture2/Core/TT.idr
+++ b/Code/Lecture2/Core/TT.idr
@@ -152,7 +152,7 @@ nameAt : {vars : _} ->
 nameAt {vars = n :: ns} Z First = n
 nameAt {vars = n :: ns} (S k) (Later p) = nameAt k p
 
-export 
+export
 {vars : _} -> Show (Term vars) where
   show tm = let (fn, args) = getFnArgs tm in showApp fn args
     where

--- a/Code/Lecture2/lecture2.ipkg
+++ b/Code/Lecture2/lecture2.ipkg
@@ -1,3 +1,10 @@
 package lecture1
 
 opts = "-p contrib"
+
+
+modules
+ = Ref
+ , Core.CaseTree
+ , Core.TT
+ , Core.Core

--- a/Code/Lecture3/TinyIdris-v1/src/Core/Core.idr
+++ b/Code/Lecture3/TinyIdris-v1/src/Core/Core.idr
@@ -98,6 +98,11 @@ export %inline
 map : (a -> b) -> Core a -> Core b
 map f (MkCore a) = MkCore (map (map f) a)
 
+-- Functor (specialised)
+export %inline
+ignore : Core a -> Core ()
+ignore = map (\ _ => ())
+
 export %inline
 (<$>) : (a -> b) -> Core a -> Core b
 (<$>) f (MkCore a) = MkCore (map (map f) a)
@@ -110,6 +115,11 @@ export %inline
                    (\x => case x of
                                Left err => pure (Left err)
                                Right val => runCore (f val)))
+
+-- Monad (specialised)
+export %inline
+(>>) : Core () -> Core b -> Core b
+ma >> mb = ma >>= \ () => mb
 
 -- Applicative (specialised)
 export %inline
@@ -153,7 +163,7 @@ traverse f xs = traverse' f xs []
 
 export
 traverseList1 : (a -> Core b) -> List1 a -> Core (List1 b)
-traverseList1 f (x :: xs) = [| f x :: traverse f xs |]
+traverseList1 f (x ::: xs) = [| f x ::: traverse f xs |]
 
 export
 traverseVect : (a -> Core b) -> Vect n a -> Core (Vect n b)
@@ -166,15 +176,15 @@ traverseOpt f Nothing = pure Nothing
 traverseOpt f (Just x) = map Just (f x)
 
 export
-traverse_ : (a -> Core b) -> List a -> Core ()
+traverse_ : (a -> Core ()) -> List a -> Core ()
 traverse_ f [] = pure ()
 traverse_ f (x :: xs)
     = do f x
          traverse_ f xs
 
 export
-traverseList1_ : (a -> Core b) -> List1 a -> Core ()
-traverseList1_ f (x :: xs) = do
+traverseList1_ : (a -> Core ()) -> List1 a -> Core ()
+traverseList1_ f (x ::: xs) = do
   f x
   traverse_ f xs
 

--- a/Code/Lecture3/TinyIdris-v1/src/Core/Env.idr
+++ b/Code/Lecture3/TinyIdris-v1/src/Core/Env.idr
@@ -13,7 +13,7 @@ revOnto xs [] = Refl
 revOnto xs (v :: vs)
     = rewrite revOnto (v :: xs) vs in
         rewrite appendAssociative (reverse vs) [v] xs in
-				  rewrite revOnto [v] vs in Refl
+          rewrite revOnto [v] vs in Refl
 
 revNs : (vs, ns : List a) -> reverse ns ++ reverse vs = reverse (vs ++ ns)
 revNs [] ns = rewrite appendNilRightNeutral (reverse ns) in Refl

--- a/Code/Lecture3/TinyIdris-v1/src/Core/TT.idr
+++ b/Code/Lecture3/TinyIdris-v1/src/Core/TT.idr
@@ -125,7 +125,7 @@ data Term : List Name -> Type where
      Erased : Term vars
 
 public export
-interface Weaken (tm : List Name -> Type) where
+interface Weaken (0 tm : List Name -> Type) where
   weaken : {n, vars : _} -> tm vars -> tm (n :: vars)
   weakenNs : {vars : _} -> (ns : List Name) -> tm vars -> tm (ns ++ vars)
 
@@ -384,7 +384,7 @@ nameAt : {vars : _} ->
 nameAt {vars = n :: ns} Z First = n
 nameAt {vars = n :: ns} (S k) (Later p) = nameAt k p
 
-export 
+export
 {vars : _} -> Show (Term vars) where
   show tm = let (fn, args) = getFnArgs tm in showApp fn args
     where

--- a/Code/Lecture3/TinyIdris-v1/src/Parser/Lexer/Package.idr
+++ b/Code/Lecture3/TinyIdris-v1/src/Parser/Lexer/Package.idr
@@ -27,7 +27,7 @@ Show Token where
   show (Comment str) = "Comment: " ++ str
   show EndOfInput = "EndOfInput"
   show Equals = "Equals"
-  show (DotSepIdent dsid) = "DotSepIdentifier: " ++ dotSep (List1.toList dsid)
+  show (DotSepIdent dsid) = "DotSepIdentifier: " ++ dotSep (forget dsid)
   show Separator = "Separator"
   show Space = "Space"
   show (StringLit s) = "StringLit: " ++ s

--- a/Code/Lecture3/TinyIdris-v1/src/Parser/Lexer/Source.idr
+++ b/Code/Lecture3/TinyIdris-v1/src/Parser/Lexer/Source.idr
@@ -46,7 +46,7 @@ Show Token where
   -- Identifiers
   show (HoleIdent x) = "hole identifier " ++ x
   show (Ident x) = "identifier " ++ x
-  show (DotSepIdent xs) = "namespaced identifier " ++ dotSep (List1.toList $ reverse xs)
+  show (DotSepIdent xs) = "namespaced identifier " ++ dotSep (forget $ reverse xs)
   show (DotIdent x) = "dot+identifier " ++ x
   show (Symbol x) = "symbol " ++ x
   -- Comments
@@ -222,7 +222,7 @@ rawTokens =
                    else Ident x
     parseNamespace : String -> Token
     parseNamespace ns = case List1.reverse . split (== '.') $ ns of
-                             [ident] => parseIdent ident
+                             (ident ::: []) => parseIdent ident
                              ns      => DotSepIdent ns
 
 export

--- a/Code/Lecture3/TinyIdris-v1/src/Parser/Rule/Package.idr
+++ b/Code/Lecture3/TinyIdris-v1/src/Parser/Rule/Package.idr
@@ -34,7 +34,7 @@ export
 exactProperty : String -> Rule String
 exactProperty p = terminal ("Expected property " ++ p)
                            (\x => case tok x of
-                                       DotSepIdent [p'] =>
+                                       DotSepIdent (p' ::: []) =>
                                          if p == p' then Just p
                                          else Nothing
                                        _ => Nothing)
@@ -64,7 +64,7 @@ export
 packageName : Rule String
 packageName = terminal "Expected package name"
                        (\x => case tok x of
-                                   DotSepIdent [str] =>
+                                   DotSepIdent (str ::: []) =>
                                      if isIdent AllowDashes str then Just str
                                      else Nothing
                                    _ => Nothing)

--- a/Code/Lecture3/TinyIdris-v1/src/Parser/Rule/Source.idr
+++ b/Code/Lecture3/TinyIdris-v1/src/Parser/Rule/Source.idr
@@ -124,7 +124,7 @@ namespacedIdent
     = terminal "Expected namespaced name"
         (\x => case tok x of
             DotSepIdent ns => Just ns
-            Ident i => Just [i]
+            Ident i => Just (i ::: [])
             _ => Nothing)
 
 export
@@ -133,7 +133,7 @@ moduleIdent
     = terminal "Expected module identifier"
         (\x => case tok x of
             DotSepIdent ns => Just ns
-            Ident i => Just [i]
+            Ident i => Just (i ::: [])
             _ => Nothing)
 
 export

--- a/Code/Lecture3/TinyIdris-v1/src/TTImp/Parser.idr
+++ b/Code/Lecture3/TinyIdris-v1/src/TTImp/Parser.idr
@@ -33,6 +33,8 @@ collectDefs : List ImpDecl -> List ImpDecl
 
 %hide Prelude.(>>=)
 %hide Core.Core.(>>=)
+%hide Prelude.(>>)
+%hide Core.Core.(>>)
 %hide Prelude.pure
 %hide Core.Core.pure
 

--- a/Code/Lecture3/TinyIdris-v1/src/Text/Literate.idr
+++ b/Code/Lecture3/TinyIdris-v1/src/Text/Literate.idr
@@ -26,6 +26,7 @@ module Text.Literate
 import Text.Lexer
 
 import Data.List
+import Data.List1
 import Data.List.Views
 import Data.Strings
 
@@ -68,7 +69,7 @@ reduce (MkToken _ _ _ _ (Any x) :: rest) acc = reduce rest (blank_content::acc)
   where
     -- Preserve the original document's line count.
     blank_content : String
-    blank_content = fastAppend (replicate (length (lines x)) "\n")
+    blank_content = fastAppend (replicate (length (forget $ lines x)) "\n")
 
 reduce (MkToken _ _ _ _ (CodeLine m src) :: rest) acc =
     if m == trim src
@@ -79,10 +80,9 @@ reduce (MkToken _ _ _ _ (CodeLine m src) :: rest) acc =
                       )::acc)
 
 reduce (MkToken _ _ _ _ (CodeBlock l r src) :: rest) acc with (lines src) -- Strip the deliminators surrounding the block.
-  reduce (MkToken _ _ _ _ (CodeBlock l r src) :: rest) acc | [] = reduce rest acc -- 1
-  reduce (MkToken _ _ _ _ (CodeBlock l r src) :: rest) acc | (s :: ys) with (snocList ys)
-    reduce (MkToken _ _ _ _ (CodeBlock l r src) :: rest) acc | (s :: []) | Empty = reduce rest acc -- 2
-    reduce (MkToken _ _ _ _ (CodeBlock l r src) :: rest) acc | (s :: (srcs ++ [f])) | (Snoc f srcs rec) =
+  reduce (MkToken _ _ _ _ (CodeBlock l r src) :: rest) acc | (s ::: ys) with (snocList ys)
+    reduce (MkToken _ _ _ _ (CodeBlock l r src) :: rest) acc | (s ::: []) | Empty = reduce rest acc -- 2
+    reduce (MkToken _ _ _ _ (CodeBlock l r src) :: rest) acc | (s ::: (srcs ++ [f])) | (Snoc f srcs rec) =
         reduce rest ("\n" :: unlines srcs :: acc)
 
 -- [ NOTE ] 1 & 2 shouldn't happen as code blocks are well formed i.e. have two deliminators.

--- a/Code/Lecture3/TinyIdris-v1/src/Text/Parser.idr
+++ b/Code/Lecture3/TinyIdris-v1/src/Text/Parser.idr
@@ -41,7 +41,7 @@ optional p = option Nothing (map Just p)
 ||| which option succeeded. If both would succeed, the left option
 ||| takes priority.
 export
-choose : {c1, c2 : Bool} -> 
+choose : {c1, c2 : Bool} ->
          (l : Grammar tok c1 a) ->
          (r : Grammar tok c2 b) ->
          Grammar tok (c1 && c2) (Either a b)
@@ -64,7 +64,7 @@ choiceMap {c} f xs = foldr (\x, acc => rewrite sym (andSameNeutral c) in
 ||| Try each grammar in a container until the first one succeeds.
 ||| Fails if the container is empty.
 export
-choice : Foldable t => 
+choice : Foldable t =>
          {c : Bool} ->
          t (Grammar tok c a) ->
          Grammar tok c a

--- a/Code/Lecture3/TinyIdris-v1/src/Text/Token.idr
+++ b/Code/Lecture3/TinyIdris-v1/src/Text/Token.idr
@@ -18,7 +18,7 @@ module Text.Token
 |||   tokValue SKComma x = ()
 ||| ```
 public export
-interface TokenKind (k : Type) where
+interface TokenKind (0 k : Type) where
   ||| The type that a token of this kind converts to.
   TokType : k -> Type
 

--- a/TinyIdris-v1/src/Core/Core.idr
+++ b/TinyIdris-v1/src/Core/Core.idr
@@ -98,6 +98,11 @@ export %inline
 map : (a -> b) -> Core a -> Core b
 map f (MkCore a) = MkCore (map (map f) a)
 
+-- Functor (specialised)
+export %inline
+ignore : Core a -> Core ()
+ignore = map (\ _ => ())
+
 export %inline
 (<$>) : (a -> b) -> Core a -> Core b
 (<$>) f (MkCore a) = MkCore (map (map f) a)
@@ -110,6 +115,11 @@ export %inline
                    (\x => case x of
                                Left err => pure (Left err)
                                Right val => runCore (f val)))
+
+-- Monad (specialised)
+export %inline
+(>>) : Core () -> Core b -> Core b
+ma >> mb = ma >>= \ () => mb
 
 -- Applicative (specialised)
 export %inline
@@ -153,7 +163,7 @@ traverse f xs = traverse' f xs []
 
 export
 traverseList1 : (a -> Core b) -> List1 a -> Core (List1 b)
-traverseList1 f (x :: xs) = [| f x :: traverse f xs |]
+traverseList1 f (x ::: xs) = [| f x ::: traverse f xs |]
 
 export
 traverseVect : (a -> Core b) -> Vect n a -> Core (Vect n b)
@@ -166,15 +176,15 @@ traverseOpt f Nothing = pure Nothing
 traverseOpt f (Just x) = map Just (f x)
 
 export
-traverse_ : (a -> Core b) -> List a -> Core ()
+traverse_ : (a -> Core ()) -> List a -> Core ()
 traverse_ f [] = pure ()
 traverse_ f (x :: xs)
     = do f x
          traverse_ f xs
 
 export
-traverseList1_ : (a -> Core b) -> List1 a -> Core ()
-traverseList1_ f (x :: xs) = do
+traverseList1_ : (a -> Core ()) -> List1 a -> Core ()
+traverseList1_ f (x ::: xs) = do
   f x
   traverse_ f xs
 

--- a/TinyIdris-v1/src/Core/TT.idr
+++ b/TinyIdris-v1/src/Core/TT.idr
@@ -125,7 +125,7 @@ data Term : List Name -> Type where
      Erased : Term vars
 
 public export
-interface Weaken (tm : List Name -> Type) where
+interface Weaken (0 tm : List Name -> Type) where
   weaken : {n, vars : _} -> tm vars -> tm (n :: vars)
   weakenNs : {vars : _} -> (ns : List Name) -> tm vars -> tm (ns ++ vars)
 
@@ -384,7 +384,7 @@ nameAt : {vars : _} ->
 nameAt {vars = n :: ns} Z First = n
 nameAt {vars = n :: ns} (S k) (Later p) = nameAt k p
 
-export 
+export
 {vars : _} -> Show (Term vars) where
   show tm = let (fn, args) = getFnArgs tm in showApp fn args
     where

--- a/TinyIdris-v1/src/Parser/Lexer/Package.idr
+++ b/TinyIdris-v1/src/Parser/Lexer/Package.idr
@@ -27,7 +27,7 @@ Show Token where
   show (Comment str) = "Comment: " ++ str
   show EndOfInput = "EndOfInput"
   show Equals = "Equals"
-  show (DotSepIdent dsid) = "DotSepIdentifier: " ++ dotSep (List1.toList dsid)
+  show (DotSepIdent dsid) = "DotSepIdentifier: " ++ dotSep (forget dsid)
   show Separator = "Separator"
   show Space = "Space"
   show (StringLit s) = "StringLit: " ++ s

--- a/TinyIdris-v1/src/Parser/Lexer/Source.idr
+++ b/TinyIdris-v1/src/Parser/Lexer/Source.idr
@@ -46,7 +46,7 @@ Show Token where
   -- Identifiers
   show (HoleIdent x) = "hole identifier " ++ x
   show (Ident x) = "identifier " ++ x
-  show (DotSepIdent xs) = "namespaced identifier " ++ dotSep (List1.toList $ reverse xs)
+  show (DotSepIdent xs) = "namespaced identifier " ++ dotSep (forget $ reverse xs)
   show (DotIdent x) = "dot+identifier " ++ x
   show (Symbol x) = "symbol " ++ x
   -- Comments
@@ -222,7 +222,7 @@ rawTokens =
                    else Ident x
     parseNamespace : String -> Token
     parseNamespace ns = case List1.reverse . split (== '.') $ ns of
-                             [ident] => parseIdent ident
+                             (ident ::: []) => parseIdent ident
                              ns      => DotSepIdent ns
 
 export

--- a/TinyIdris-v1/src/Parser/Rule/Package.idr
+++ b/TinyIdris-v1/src/Parser/Rule/Package.idr
@@ -34,7 +34,7 @@ export
 exactProperty : String -> Rule String
 exactProperty p = terminal ("Expected property " ++ p)
                            (\x => case tok x of
-                                       DotSepIdent [p'] =>
+                                       DotSepIdent (p' ::: []) =>
                                          if p == p' then Just p
                                          else Nothing
                                        _ => Nothing)
@@ -64,7 +64,7 @@ export
 packageName : Rule String
 packageName = terminal "Expected package name"
                        (\x => case tok x of
-                                   DotSepIdent [str] =>
+                                   DotSepIdent (str ::: []) =>
                                      if isIdent AllowDashes str then Just str
                                      else Nothing
                                    _ => Nothing)

--- a/TinyIdris-v1/src/Parser/Rule/Source.idr
+++ b/TinyIdris-v1/src/Parser/Rule/Source.idr
@@ -124,7 +124,7 @@ namespacedIdent
     = terminal "Expected namespaced name"
         (\x => case tok x of
             DotSepIdent ns => Just ns
-            Ident i => Just [i]
+            Ident i => Just (i ::: [])
             _ => Nothing)
 
 export
@@ -133,7 +133,7 @@ moduleIdent
     = terminal "Expected module identifier"
         (\x => case tok x of
             DotSepIdent ns => Just ns
-            Ident i => Just [i]
+            Ident i => Just (i ::: [])
             _ => Nothing)
 
 export

--- a/TinyIdris-v1/src/TTImp/Parser.idr
+++ b/TinyIdris-v1/src/TTImp/Parser.idr
@@ -31,6 +31,8 @@ collectDefs : List ImpDecl -> List ImpDecl
 
 %default covering
 
+%hide Prelude.(>>)
+%hide Core.Core.(>>)
 %hide Prelude.(>>=)
 %hide Core.Core.(>>=)
 %hide Prelude.pure

--- a/TinyIdris-v1/src/Text/Literate.idr
+++ b/TinyIdris-v1/src/Text/Literate.idr
@@ -26,6 +26,7 @@ module Text.Literate
 import Text.Lexer
 
 import Data.List
+import Data.List1
 import Data.List.Views
 import Data.Strings
 
@@ -68,7 +69,7 @@ reduce (MkToken _ _ _ _ (Any x) :: rest) acc = reduce rest (blank_content::acc)
   where
     -- Preserve the original document's line count.
     blank_content : String
-    blank_content = fastAppend (replicate (length (lines x)) "\n")
+    blank_content = fastAppend (replicate (length (forget $ lines x)) "\n")
 
 reduce (MkToken _ _ _ _ (CodeLine m src) :: rest) acc =
     if m == trim src
@@ -79,10 +80,9 @@ reduce (MkToken _ _ _ _ (CodeLine m src) :: rest) acc =
                       )::acc)
 
 reduce (MkToken _ _ _ _ (CodeBlock l r src) :: rest) acc with (lines src) -- Strip the deliminators surrounding the block.
-  reduce (MkToken _ _ _ _ (CodeBlock l r src) :: rest) acc | [] = reduce rest acc -- 1
-  reduce (MkToken _ _ _ _ (CodeBlock l r src) :: rest) acc | (s :: ys) with (snocList ys)
-    reduce (MkToken _ _ _ _ (CodeBlock l r src) :: rest) acc | (s :: []) | Empty = reduce rest acc -- 2
-    reduce (MkToken _ _ _ _ (CodeBlock l r src) :: rest) acc | (s :: (srcs ++ [f])) | (Snoc f srcs rec) =
+  reduce (MkToken _ _ _ _ (CodeBlock l r src) :: rest) acc | (s ::: ys) with (snocList ys)
+    reduce (MkToken _ _ _ _ (CodeBlock l r src) :: rest) acc | (s ::: []) | Empty = reduce rest acc -- 2
+    reduce (MkToken _ _ _ _ (CodeBlock l r src) :: rest) acc | (s ::: (srcs ++ [f])) | (Snoc f srcs rec) =
         reduce rest ("\n" :: unlines srcs :: acc)
 
 -- [ NOTE ] 1 & 2 shouldn't happen as code blocks are well formed i.e. have two deliminators.

--- a/TinyIdris-v1/src/Text/Token.idr
+++ b/TinyIdris-v1/src/Text/Token.idr
@@ -18,7 +18,7 @@ module Text.Token
 |||   tokValue SKComma x = ()
 ||| ```
 public export
-interface TokenKind (k : Type) where
+interface TokenKind (0 k : Type) where
   ||| The type that a token of this kind converts to.
   TokType : k -> Type
 

--- a/TinyIdris-v2/src/Core/Core.idr
+++ b/TinyIdris-v2/src/Core/Core.idr
@@ -98,6 +98,11 @@ export %inline
 map : (a -> b) -> Core a -> Core b
 map f (MkCore a) = MkCore (map (map f) a)
 
+-- Functor (specialised)
+export %inline
+ignore : Core a -> Core ()
+ignore = map (\ _ => ())
+
 export %inline
 (<$>) : (a -> b) -> Core a -> Core b
 (<$>) f (MkCore a) = MkCore (map (map f) a)
@@ -110,6 +115,11 @@ export %inline
                    (\x => case x of
                                Left err => pure (Left err)
                                Right val => runCore (f val)))
+
+-- Monad (specialised)
+export %inline
+(>>) : Core () -> Core b -> Core b
+ma >> mb = ma >>= \ () => mb
 
 -- Applicative (specialised)
 export %inline
@@ -153,7 +163,7 @@ traverse f xs = traverse' f xs []
 
 export
 traverseList1 : (a -> Core b) -> List1 a -> Core (List1 b)
-traverseList1 f (x :: xs) = [| f x :: traverse f xs |]
+traverseList1 f (x ::: xs) = [| f x ::: traverse f xs |]
 
 export
 traverseVect : (a -> Core b) -> Vect n a -> Core (Vect n b)
@@ -166,15 +176,15 @@ traverseOpt f Nothing = pure Nothing
 traverseOpt f (Just x) = map Just (f x)
 
 export
-traverse_ : (a -> Core b) -> List a -> Core ()
+traverse_ : (a -> Core ()) -> List a -> Core ()
 traverse_ f [] = pure ()
 traverse_ f (x :: xs)
     = do f x
          traverse_ f xs
 
 export
-traverseList1_ : (a -> Core b) -> List1 a -> Core ()
-traverseList1_ f (x :: xs) = do
+traverseList1_ : (a -> Core ()) -> List1 a -> Core ()
+traverseList1_ f (x ::: xs) = do
   f x
   traverse_ f xs
 

--- a/TinyIdris-v2/src/Core/Normalise.idr
+++ b/TinyIdris-v2/src/Core/Normalise.idr
@@ -14,7 +14,7 @@ import Data.Vect
 -- part will only be constructed when needed, because it's in Core.
 public export
 data Glued : List Name -> Type where
-     MkGlue : Core (Term vars) -> 
+     MkGlue : Core (Term vars) ->
               (Ref Ctxt Defs -> Core (NF vars)) -> Glued vars
 
 export
@@ -39,7 +39,7 @@ data CaseResult a
      = Result a
      | NoMatch -- case alternative didn't match anything
      | GotStuck -- alternative matched, but got stuck later
- 
+
 -- So that we can call 'eval' with new defs
 evalTop : {free, vars : _} ->
           Defs -> Env Term free -> LocalEnv free vars ->
@@ -247,11 +247,12 @@ export
 data QVar : Type where
 
 public export
-interface Quote (tm : List Name -> Type) where
+interface Quote (0 tm : List Name -> Type) where
     quote : {vars : _} ->
             Defs -> Env Term vars -> tm vars -> Core (Term vars)
     quoteGen : {vars : _} ->
-               Ref QVar Int -> Defs -> Env Term vars -> tm vars -> Core (Term vars)
+               Ref QVar Int -> Defs -> Env Term vars ->
+               tm vars -> Core (Term vars)
 
     quote defs env tm
         = do q <- newRef QVar 0

--- a/TinyIdris-v2/src/Core/TT.idr
+++ b/TinyIdris-v2/src/Core/TT.idr
@@ -131,7 +131,7 @@ data Term : List Name -> Type where
      Erased : Term vars
 
 public export
-interface Weaken (tm : List Name -> Type) where
+interface Weaken (0 tm : List Name -> Type) where
   weaken : {n, vars : _} -> tm vars -> tm (n :: vars)
   weakenNs : {vars : _} -> (ns : List Name) -> tm vars -> tm (ns ++ vars)
 
@@ -458,7 +458,7 @@ nameAt : {vars : _} ->
 nameAt {vars = n :: ns} Z First = n
 nameAt {vars = n :: ns} (S k) (Later p) = nameAt k p
 
-export 
+export
 {vars : _} -> Show (Term vars) where
   show tm = let (fn, args) = getFnArgs tm in showApp fn args
     where

--- a/TinyIdris-v2/src/Core/Unify.idr
+++ b/TinyIdris-v2/src/Core/Unify.idr
@@ -21,7 +21,7 @@ record UnifyResult where
   holesSolved : Bool -- did we solve any holes on the way?
 
 public export
-interface Unify (tm : List Name -> Type) where
+interface Unify (0 tm : List Name -> Type) where
   unify : {vars : _} ->
           {auto c : Ref Ctxt Defs} ->
           {auto u : Ref UST UState} ->
@@ -304,7 +304,7 @@ mutual
                        empty <- clearDefs defs
                        tm <- quote empty env tmnf
                        case shrinkTerm tm submv of
-                            Nothing => 
+                            Nothing =>
                               -- Not well scoped, but it might be if we
                               -- normalise (TODO: Exercise)
                               postpone env (NApp (NMeta n margs) fargs) tmnf
@@ -396,7 +396,7 @@ retryGuess n
     = do defs <- get Ctxt
          case !(lookupDef n defs) of
               Nothing => pure False
-              Just gdef => 
+              Just gdef =>
                 case definition gdef of
                      Guess tm cs =>
                         do cs' <- traverse retry cs

--- a/TinyIdris-v2/src/Parser/Lexer/Package.idr
+++ b/TinyIdris-v2/src/Parser/Lexer/Package.idr
@@ -27,7 +27,7 @@ Show Token where
   show (Comment str) = "Comment: " ++ str
   show EndOfInput = "EndOfInput"
   show Equals = "Equals"
-  show (DotSepIdent dsid) = "DotSepIdentifier: " ++ dotSep (List1.toList dsid)
+  show (DotSepIdent dsid) = "DotSepIdentifier: " ++ dotSep (forget dsid)
   show Separator = "Separator"
   show Space = "Space"
   show (StringLit s) = "StringLit: " ++ s

--- a/TinyIdris-v2/src/Parser/Lexer/Source.idr
+++ b/TinyIdris-v2/src/Parser/Lexer/Source.idr
@@ -46,7 +46,7 @@ Show Token where
   -- Identifiers
   show (HoleIdent x) = "hole identifier " ++ x
   show (Ident x) = "identifier " ++ x
-  show (DotSepIdent xs) = "namespaced identifier " ++ dotSep (List1.toList $ reverse xs)
+  show (DotSepIdent xs) = "namespaced identifier " ++ dotSep (forget $ reverse xs)
   show (DotIdent x) = "dot+identifier " ++ x
   show (Symbol x) = "symbol " ++ x
   -- Comments
@@ -222,7 +222,7 @@ rawTokens =
                    else Ident x
     parseNamespace : String -> Token
     parseNamespace ns = case List1.reverse . split (== '.') $ ns of
-                             [ident] => parseIdent ident
+                             (ident ::: []) => parseIdent ident
                              ns      => DotSepIdent ns
 
 export

--- a/TinyIdris-v2/src/Parser/Rule/Package.idr
+++ b/TinyIdris-v2/src/Parser/Rule/Package.idr
@@ -34,7 +34,7 @@ export
 exactProperty : String -> Rule String
 exactProperty p = terminal ("Expected property " ++ p)
                            (\x => case tok x of
-                                       DotSepIdent [p'] =>
+                                       DotSepIdent (p' ::: []) =>
                                          if p == p' then Just p
                                          else Nothing
                                        _ => Nothing)
@@ -64,7 +64,7 @@ export
 packageName : Rule String
 packageName = terminal "Expected package name"
                        (\x => case tok x of
-                                   DotSepIdent [str] =>
+                                   DotSepIdent (str ::: []) =>
                                      if isIdent AllowDashes str then Just str
                                      else Nothing
                                    _ => Nothing)

--- a/TinyIdris-v2/src/Parser/Rule/Source.idr
+++ b/TinyIdris-v2/src/Parser/Rule/Source.idr
@@ -124,7 +124,7 @@ namespacedIdent
     = terminal "Expected namespaced name"
         (\x => case tok x of
             DotSepIdent ns => Just ns
-            Ident i => Just [i]
+            Ident i => Just (i ::: [])
             _ => Nothing)
 
 export
@@ -133,7 +133,7 @@ moduleIdent
     = terminal "Expected module identifier"
         (\x => case tok x of
             DotSepIdent ns => Just ns
-            Ident i => Just [i]
+            Ident i => Just (i ::: [])
             _ => Nothing)
 
 export

--- a/TinyIdris-v2/src/TTImp/Parser.idr
+++ b/TinyIdris-v2/src/TTImp/Parser.idr
@@ -33,6 +33,8 @@ collectDefs : List ImpDecl -> List ImpDecl
 
 %hide Prelude.(>>=)
 %hide Core.Core.(>>=)
+%hide Prelude.(>>)
+%hide Core.Core.(>>)
 %hide Prelude.pure
 %hide Core.Core.pure
 

--- a/TinyIdris-v2/src/Text/Literate.idr
+++ b/TinyIdris-v2/src/Text/Literate.idr
@@ -25,6 +25,7 @@ module Text.Literate
 
 import Text.Lexer
 
+import Data.List1
 import Data.List
 import Data.List.Views
 import Data.Strings
@@ -68,7 +69,7 @@ reduce (MkToken _ _ _ _ (Any x) :: rest) acc = reduce rest (blank_content::acc)
   where
     -- Preserve the original document's line count.
     blank_content : String
-    blank_content = fastAppend (replicate (length (lines x)) "\n")
+    blank_content = fastAppend (replicate (length (forget $ lines x)) "\n")
 
 reduce (MkToken _ _ _ _ (CodeLine m src) :: rest) acc =
     if m == trim src
@@ -79,10 +80,9 @@ reduce (MkToken _ _ _ _ (CodeLine m src) :: rest) acc =
                       )::acc)
 
 reduce (MkToken _ _ _ _ (CodeBlock l r src) :: rest) acc with (lines src) -- Strip the deliminators surrounding the block.
-  reduce (MkToken _ _ _ _ (CodeBlock l r src) :: rest) acc | [] = reduce rest acc -- 1
-  reduce (MkToken _ _ _ _ (CodeBlock l r src) :: rest) acc | (s :: ys) with (snocList ys)
-    reduce (MkToken _ _ _ _ (CodeBlock l r src) :: rest) acc | (s :: []) | Empty = reduce rest acc -- 2
-    reduce (MkToken _ _ _ _ (CodeBlock l r src) :: rest) acc | (s :: (srcs ++ [f])) | (Snoc f srcs rec) =
+  reduce (MkToken _ _ _ _ (CodeBlock l r src) :: rest) acc | (s ::: ys) with (snocList ys)
+    reduce (MkToken _ _ _ _ (CodeBlock l r src) :: rest) acc | (s ::: []) | Empty = reduce rest acc -- 2
+    reduce (MkToken _ _ _ _ (CodeBlock l r src) :: rest) acc | (s ::: (srcs ++ [f])) | (Snoc f srcs rec) =
         reduce rest ("\n" :: unlines srcs :: acc)
 
 -- [ NOTE ] 1 & 2 shouldn't happen as code blocks are well formed i.e. have two deliminators.

--- a/TinyIdris-v2/src/Text/Token.idr
+++ b/TinyIdris-v2/src/Text/Token.idr
@@ -18,7 +18,7 @@ module Text.Token
 |||   tokValue SKComma x = ()
 ||| ```
 public export
-interface TokenKind (k : Type) where
+interface TokenKind (0 k : Type) where
   ||| The type that a token of this kind converts to.
   TokType : k -> Type
 


### PR DESCRIPTION
Following https://github.com/idris-lang/Idris2/issues/1291 here is an updated version of the code
in this repository to work with the current dev version of idris.

Unfortunately I don't know how to install multiple version in parallel so I can't check
that it works with 0.3.0 too. I suppose I could add CI to this repo if you want to make
sure it does work.

Note that `idris2 --build lecture2.ipkg` fails because of a missing `insertNVarNames`.
Adding it to `Core.TT` would require pulling in new notions like `NVar` but I'm not
sure whether this is intended (I must admit I don't remember whether lecture 2 had
already covered these topics).